### PR TITLE
Bugfix/mondo equivalence

### DIFF
--- a/oan-etl/pom.xml
+++ b/oan-etl/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jax.oan</groupId>
         <artifactId>ontology-annotation-network</artifactId>
-        <version>1.0.6</version>
+        <version>1.0.7</version>
     </parent>
 
     <artifactId>oan-etl</artifactId>

--- a/oan-etl/src/main/java/org/jax/oan/ontology/HpoOntologyAnnotationLoader.java
+++ b/oan-etl/src/main/java/org/jax/oan/ontology/HpoOntologyAnnotationLoader.java
@@ -16,10 +16,7 @@ import org.monarchinitiative.phenol.annotations.io.hpo.DiseaseDatabase;
 import org.monarchinitiative.phenol.annotations.io.hpo.HpoaDiseaseDataContainer;
 import org.monarchinitiative.phenol.annotations.io.hpo.HpoaDiseaseDataLoader;
 import org.monarchinitiative.phenol.io.OntologyLoader;
-import org.monarchinitiative.phenol.ontology.data.Dbxref;
-import org.monarchinitiative.phenol.ontology.data.Ontology;
-import org.monarchinitiative.phenol.ontology.data.Term;
-import org.monarchinitiative.phenol.ontology.data.TermId;
+import org.monarchinitiative.phenol.ontology.data.*;
 import org.neo4j.driver.Query;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -263,8 +260,12 @@ public class HpoOntologyAnnotationLoader implements OntologyAnnotationLoader {
 	static Optional<Term> findMondoEquivalent(TermId target, Collection<Term> diseases){
 		return diseases.stream().filter(term ->
 				term.getXrefs().stream().map(Dbxref::getName).map(TermId::of).anyMatch(s ->
-					s.getValue().equals(target.toString()) || s.getValue().equals(
-							TermId.of(AlternativePrefix.from(target.getPrefix()), s.getId()).getValue())
-		)).findFirst();
+						s.getValue().equals(target.toString()) || s.getValue().equals(
+								TermId.of(AlternativePrefix.from(target.getPrefix()), target.getId()).getValue())
+				)
+
+		).findFirst();
+
+
 	}
 }

--- a/oan-etl/src/main/java/org/jax/oan/ontology/HpoOntologyAnnotationLoader.java
+++ b/oan-etl/src/main/java/org/jax/oan/ontology/HpoOntologyAnnotationLoader.java
@@ -114,7 +114,7 @@ public class HpoOntologyAnnotationLoader implements OntologyAnnotationLoader {
 		logger.info("Loading Diseases...");
 		ArrayList<Query> queries = new ArrayList<>(Collections.emptyList());
 		diseases.diseaseData().stream().distinct().forEach(d -> {
-					Optional<Term> equivalent = findMondoEquivalent(d.id(), mondoTerms);
+					Optional<Term> equivalent = findMondoEquivalent(d.id(), d.name(), mondoTerms);
 					String mondoId = "";
 					String description = "No disease description found.";
 					if (equivalent.isPresent()){
@@ -257,15 +257,32 @@ public class HpoOntologyAnnotationLoader implements OntologyAnnotationLoader {
 		return frequency;
 	}
 
-	static Optional<Term> findMondoEquivalent(TermId target, Collection<Term> diseases){
-		return diseases.stream().filter(term ->
+	static Optional<Term> findMondoEquivalent(TermId target, String targetName, Collection<Term> diseases){
+		 List<Term> equivalence = diseases.stream().filter(term ->
 				term.getXrefs().stream().map(Dbxref::getName).map(TermId::of).anyMatch(s ->
 						s.getValue().equals(target.toString()) || s.getValue().equals(
 								TermId.of(AlternativePrefix.from(target.getPrefix()), target.getId()).getValue())
 				)
 
-		).findFirst();
+		).toList();
 
-
+		 if (equivalence.isEmpty()) {
+			 return Optional.empty();
+		 } else if (equivalence.size() > 1) {
+			  // Sometimes we have errenous equivalence so we want to then see if we can find if the names start with each other
+			 // Make sure our target has a name
+			 if (targetName.length() > 3){
+				 List<Term> equivalenceByName = equivalence.stream().filter(a -> a.getName().toLowerCase().startsWith(targetName.substring(0, 3).toLowerCase())).toList();
+				 if (equivalenceByName.isEmpty()){
+					 return Optional.empty();
+				 } else {
+					 return equivalenceByName.stream().findFirst();
+				 }
+			 } else {
+				 return Optional.empty();
+			 }
+		 } else {
+			 return equivalence.stream().findFirst();
+		 }
 	}
 }

--- a/oan-etl/src/test/java/org/jax/oan/ontology/HpoOntologyAnnotationLoaderTest.java
+++ b/oan-etl/src/test/java/org/jax/oan/ontology/HpoOntologyAnnotationLoaderTest.java
@@ -19,10 +19,7 @@ import org.neo4j.driver.types.Node;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 import org.monarchinitiative.phenol.ontology.data.TermId;
@@ -156,18 +153,59 @@ class HpoOntologyAnnotationLoaderTest {
 	}
 
 	@Test
-	void findMondoEquivalent(){
+	void findMondoEquivalentFromSingleMatchingOne(){
 		TermId targetId = TermId.of("ORPHA:619340");
-		Term target = Term.builder(TermId.of("MONDO:999999")).databaseXrefs(
+		Term target = Term.builder(targetId).xrefs(
 				List.of(
-						new SimpleXref("Orphanet:0999923"),
-						new SimpleXref("Orphanet:619340")
+						new Dbxref("Orphanet:619340", "", null),
+						new Dbxref("OMIM:619340", "", null)
 				)
 		).name("Bad Disease 1").build();
 		Collection<Term> diseases = List.of(target);
 
-		assertEquals(target, HpoOntologyAnnotationLoader.findMondoEquivalent(targetId, diseases).orElse(null));
+		assertEquals(target, HpoOntologyAnnotationLoader.findMondoEquivalent(targetId, "Bad Disease 1", diseases).orElse(null));
 	}
+
+	@Test
+	void findMondoEquivalentFromMultipleMatchingTwo(){
+		TermId targetId = TermId.of("ORPHA:619340");
+		Term target = Term.builder(targetId).xrefs(
+				List.of(
+						new Dbxref("Orphanet:619340", "", null),
+						new Dbxref("OMIM:619340", "", null)
+				)
+		).name("Bad Disease 2").build();
+		Term target2 = Term.builder(targetId).xrefs(
+				List.of(
+						new Dbxref("Orphanet:619340", "", null),
+						new Dbxref("OMIM:619340", "", null)
+				)
+		).name("Other Disease 3").build();
+		Collection<Term> diseases = List.of(target, target2);
+
+		assertEquals(target2, HpoOntologyAnnotationLoader.findMondoEquivalent(targetId, "Other Disease 3", diseases).orElse(null));
+	}
+
+	@Test
+	void findMondoEquivalentFromMultipleMatchingNoneByName(){
+		TermId targetId = TermId.of("ORPHA:619340");
+		Term target = Term.builder(targetId).xrefs(
+				List.of(
+						new Dbxref("Orphanet:619340", "", null),
+						new Dbxref("OMIM:619340", "", null)
+				)
+		).name("Bad Disease 2").build();
+		Term target2 = Term.builder(targetId).xrefs(
+				List.of(
+						new Dbxref("Orphanet:619340", "", null),
+						new Dbxref("OMIM:619340", "", null)
+				)
+		).name("Other Disease 3").build();
+		Collection<Term> diseases = List.of(target, target2);
+
+		assertEquals(Optional.empty(), HpoOntologyAnnotationLoader.findMondoEquivalent(targetId, "Quadri Disease", diseases));
+	}
+
 
 	@Test
 	void phenotypeToCategory(){

--- a/oan-etl/src/test/java/org/jax/oan/ontology/HpoOntologyAnnotationLoaderTest.java
+++ b/oan-etl/src/test/java/org/jax/oan/ontology/HpoOntologyAnnotationLoaderTest.java
@@ -157,10 +157,11 @@ class HpoOntologyAnnotationLoaderTest {
 
 	@Test
 	void findMondoEquivalent(){
-		TermId targetId = TermId.of("OMIM:619340");
-		Term target = Term.builder(targetId).xrefs(
+		TermId targetId = TermId.of("ORPHA:619340");
+		Term target = Term.builder(TermId.of("MONDO:999999")).databaseXrefs(
 				List.of(
-						new Dbxref("OMIM:619340", "", null)
+						new SimpleXref("Orphanet:0999923"),
+						new SimpleXref("Orphanet:619340")
 				)
 		).name("Bad Disease 1").build();
 		Collection<Term> diseases = List.of(target);

--- a/oan-model/pom.xml
+++ b/oan-model/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jax.oan</groupId>
         <artifactId>ontology-annotation-network</artifactId>
-        <version>1.0.6</version>
+        <version>1.0.7</version>
     </parent>
 
     <artifactId>oan-model</artifactId>

--- a/oan-model/src/main/java/org/jax/oan/core/AlternativePrefix.java
+++ b/oan-model/src/main/java/org/jax/oan/core/AlternativePrefix.java
@@ -9,6 +9,6 @@ public class AlternativePrefix {
 		if (prefixMap.containsKey(prefix)){
 			return prefixMap.get(prefix);
 		}
-		return "NULL";
+		return prefix;
 	}
 }

--- a/oan-rest/pom.xml
+++ b/oan-rest/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jax.oan</groupId>
         <artifactId>ontology-annotation-network</artifactId>
-        <version>1.0.6</version>
+        <version>1.0.7</version>
     </parent>
 
     <artifactId>oan-rest</artifactId>

--- a/oan-rest/src/main/java/org/jax/oan/Application.java
+++ b/oan-rest/src/main/java/org/jax/oan/Application.java
@@ -12,7 +12,7 @@ import io.swagger.v3.oas.annotations.servers.Server;
 @OpenAPIDefinition(
     info = @Info(
             title = "ontology-annotation-network",
-            version = "1.0.6",
+            version = "1.0.7",
             description = "A restful service for access to the ontology annotation network.",
             contact = @Contact(name = "Michael Gargano", email = "Michael.Gargano@jax.org")
     ), servers = {@Server(url = "https://ontology.jax.org/api/network", description = "Production Server URL")

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>org.jax.oan</groupId>
   <artifactId>ontology-annotation-network</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.6</version>
+  <version>1.0.7</version>
 
   <name>ontology-annotation-network</name>
   <url>https://github.com/TheJacksonLaboratory/ontology-annotation-network</url>


### PR DESCRIPTION
- This is a temporary fix to a longer standing problem of disease equivalence that should be solved with sssom-api. Until then we use xrefs and partial name matches to resolve equivalencies.
- Sometimes xref to other diseases exist in the list that are not "exact matches"